### PR TITLE
Fix nextjs auth0 setup.

### DIFF
--- a/memomatch/package-lock.json
+++ b/memomatch/package-lock.json
@@ -8,7 +8,7 @@
       "name": "memomatch",
       "version": "0.1.0",
       "dependencies": {
-        "@auth0/auth0-react": "^2.2.4",
+        "@auth0/nextjs-auth0": "^3.5.0",
         "jotai": "^2.6.1",
         "next": "14.0.4",
         "partysocket": "0.0.19",
@@ -50,22 +50,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@auth0/auth0-react": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-react/-/auth0-react-2.2.4.tgz",
-      "integrity": "sha512-l29PQC0WdgkCoOc6WeMAY26gsy/yXJICW0jHfj0nz8rZZphYKrLNqTRWFFCMJY+sagza9tSgB1kG/UvQYgGh9A==",
+    "node_modules/@auth0/nextjs-auth0": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@auth0/nextjs-auth0/-/nextjs-auth0-3.5.0.tgz",
+      "integrity": "sha512-uFZEE2QQf1zU+jRK2fwqxRQt+WSqDPYF2tnr7d6BEa7b6L6tpPJ3evzoImbWSY1a7gFdvD7RD/Rvrsx7B5CKVg==",
       "dependencies": {
-        "@auth0/auth0-spa-js": "^2.1.3"
+        "@panva/hkdf": "^1.0.2",
+        "cookie": "^0.6.0",
+        "debug": "^4.3.4",
+        "joi": "^17.6.0",
+        "jose": "^4.9.2",
+        "oauth4webapi": "^2.3.0",
+        "openid-client": "^5.2.1",
+        "tslib": "^2.4.0",
+        "url-join": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^16.11.0 || ^17 || ^18",
-        "react-dom": "^16.11.0 || ^17 || ^18"
+        "next": ">=10"
       }
-    },
-    "node_modules/@auth0/auth0-spa-js": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.1.3.tgz",
-      "integrity": "sha512-NMTBNuuG4g3rame1aCnNS5qFYIzsTUV5qTFPRfTyYFS1feS6jsCBR+eTq9YkxCp1yuoM2UIcjunPaoPl77U9xQ=="
     },
     "node_modules/@babel/runtime": {
       "version": "7.23.9",
@@ -610,6 +615,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -919,6 +937,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@panva/hkdf": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.1.1.tgz",
+      "integrity": "sha512-dhPeilub1NuIG0X5Kvhh9lH4iW3ZsHlnzwgwbOlgwQ2wG1IqFzsgHqmKPk3WzsdWAeaxKJxgM0+W433RmN45GA==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -934,6 +960,24 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.7.1.tgz",
       "integrity": "sha512-irBNt5094vHloql4QzY8RdeI8Tns2kGsaiJ/m6jENWx9xCz/m/F4gKQ1dAailFmpL0Id9tgWLqZbTUO4SINM/Q==",
       "dev": true
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.2",
@@ -1705,6 +1749,14 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1791,7 +1843,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -3553,6 +3604,26 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/joi": {
+      "version": "17.12.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.0.tgz",
+      "integrity": "sha512-HSLsmSmXz+PV9PYoi3p7cgIbj06WnEBNT28n+bbBNcPZXZFqCzzvGqpTBPujx/Z0nh1+KNQPDrNgdmQ8dq0qYw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.4",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.4.tgz",
+      "integrity": "sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/jotai": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.6.3.tgz",
@@ -3726,7 +3797,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3833,8 +3903,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mustache": {
       "version": "4.2.0",
@@ -4003,6 +4072,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/oauth4webapi": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.8.1.tgz",
+      "integrity": "sha512-Jm1Z6eUumtevQWxMllSw+4diHOcFyxuc3KAXoyh4fbpHndbXRbviyrLoCn8htEdHYZM/MIOVbeWjDk86BxVF+A==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4010,6 +4087,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -4121,6 +4206,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oidc-token-hash": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
+      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4143,6 +4236,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.4.tgz",
+      "integrity": "sha512-T1h3B10BRPKfcObdBklX639tVz+xh34O7GjofqrqiAQdm7eHsQ00ih18x6wuJ/E6FxdtS2u3FmUGPDeEcMwzNA==",
+      "dependencies": {
+        "jose": "^4.15.4",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/optionator": {
@@ -5516,6 +5623,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -5769,8 +5881,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "2.3.4",

--- a/memomatch/package.json
+++ b/memomatch/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@auth0/auth0-react": "^2.2.4",
+    "@auth0/nextjs-auth0": "^3.5.0",
     "jotai": "^2.6.1",
     "next": "14.0.4",
     "partysocket": "0.0.19",

--- a/memomatch/src/app/api/auth/[auth0]/route.js
+++ b/memomatch/src/app/api/auth/[auth0]/route.js
@@ -1,0 +1,3 @@
+import { handleAuth } from "@auth0/nextjs-auth0";
+
+export const GET = handleAuth();

--- a/memomatch/src/app/game/page.tsx
+++ b/memomatch/src/app/game/page.tsx
@@ -1,16 +1,16 @@
 "use client";
 import Game from "@/components/Game";
-import { useParams } from "next/navigation";
-import { userAtom } from '../../../state/atoms'
-import { useAtom } from "jotai";
+import { useUser } from "@auth0/nextjs-auth0/client";
 
 export default function MyGame() {
-  const [user, setUser] = useAtom(userAtom);
-  //const params = useParams<{ username: string }>();
+  const { user, error, isLoading } = useUser();
+
+  if (isLoading || user === undefined) return <div>Loading...</div>;
+  if (error) return <div>{error.message}</div>;
 
   return (
     <div>
-      <Game roomId={"my-room"} username={user.name ?? 'Anonymous'}></Game>
+      <Game roomId={"my-room"} username={user.name ?? "Anonymous"}></Game>
     </div>
   );
 }

--- a/memomatch/src/app/layout.tsx
+++ b/memomatch/src/app/layout.tsx
@@ -1,7 +1,5 @@
-
 import type { Metadata } from "next";
-//import { UserProvider } from '@auth0/nextjs-auth0/client';
-import { Auth0Provider } from '@auth0/auth0-react';
+import { UserProvider } from "@auth0/nextjs-auth0/client";
 
 // These styles apply to every route in the application
 import "./globals.css";
@@ -17,13 +15,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <Auth0Provider
-      domain="dev-6nw16umezarw38ei.us.auth0.com"
-      clientId="Fqoh1lC9gjaea9fVwkWbUaYhOm9k2FoT"
-      authorizationParams={{
-        redirect_uri: window.location.origin
-      }}
-    >
+    <UserProvider>
       <html lang="en">
         <head>
           <meta charSet="UTF-8" />
@@ -38,6 +30,6 @@ export default function RootLayout({
           </main>
         </body>
       </html>
-    </Auth0Provider>
+    </UserProvider>
   );
 }

--- a/memomatch/src/app/page.tsx
+++ b/memomatch/src/app/page.tsx
@@ -1,12 +1,7 @@
 "use client";
-import Game from "@/components/Game";
-import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
-import { userAtom, User } from '../../state/atoms'
-import { useAtom, atom } from "jotai";
+import { atom, useAtom } from "jotai";
+import { useRouter } from "next/navigation";
 import { z } from "zod";
-import { useAuth0 } from "@auth0/auth0-react";
-
 
 const queryParamsValidator = z.object({
   username: z.string().min(1),
@@ -19,91 +14,17 @@ interface GameSetup {
 const GameSetupAtom = atom<GameSetup>({ username: null });
 
 export default function Login() {
-  const [user, setUser] = useAtom(userAtom)
-  const [setup, setSetup] = useAtom(GameSetupAtom); 
-  const { loginWithRedirect } = useAuth0();
+  const [setup, setSetup] = useAtom(GameSetupAtom);
 
   const router = useRouter();
-  const query = useSearchParams();
-
-  useEffect(() => {
-    if (router) {
-      const parsed = queryParamsValidator.safeParse(query);
-      if (parsed.success) {
-        setSetup(() => ({
-          username: parsed.data.username,
-        }));
-      }
-    }
-  }, [router, setSetup, query]);
-
-  const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    if (!user.name) {
-      alert("Please provide a username!");
-    }
-    /*
-        else if (!user.password) {
-          alert("Please provide a password!");
-        }
-    */
-
-    else {
-      loginWithRedirect()
-      //router.push('/api/auth/login');
-      //router.push('/game')
-      
-    }
-
-  };
 
   return (
     <section className="mydiv">
       <div className=" flex flex-col gap-5 items-center">
         <h3>Login</h3>
-        <form className=" flex flex-col gap-7 items-center"
-          onSubmit={handleFormSubmit}
-        >
-          <label htmlFor="username" hidden>
-            Username
-          </label>
-          <input
-            className="input"
-            type="text"
-            value={user.name || ""}
-            onChange={(e) => {
-              setUser({ name: e.currentTarget.value, password: user.password });
-              setSetup({ username: user.name });
-            }}
-            name="username"
-            id="username"
-            placeholder="username"
-          />
-          {/*}
-          <input
-            className="input"
-            type="password" // password is hidden
-            value={user.password || ""}
-            onChange={(e) => setUser({ name: user.name, password: e.currentTarget.value })}
-            name="password"
-            id="password"
-            placeholder="password"
-          />
-          {*/}
-          <button className="btn btn-wide">log in</button>
-        </form>
-
-        {/*}
-        <button
-          className="link"
-          onClick={() => {
-            router.push("/register");
-          }}
-        >
-          or register now
-        </button>
-        {*/}
+        <a className="btn btn-wide" href="/api/auth/login?returnTo=/game">
+          Login
+        </a>
       </div>
     </section>
   );


### PR DESCRIPTION
Hi team Memomatch. 

The basic issue with the Auth0Provider was, that it would only work in client side react. As next.js will build a static HTML version for the server and then a client side version with react that will only load javascript then on the client, the Auth0 setup for standard SPAs from https://auth0.com/docs/quickstart/spa/react/01-login does not really work. 

Following the tutorial for the nextjs setup worked out quite well: https://auth0.com/docs/quickstart/webapp/nextjs/01-login

It's important to create the `.env.local` file, as defined here: https://auth0.com/docs/quickstart/webapp/nextjs/01-login#configure-the-sdk

Remaining infos are in the diff comments.
